### PR TITLE
Fix bug with passing travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - '10'
-  
+
 install:
   - npm install
 cache:
@@ -9,5 +9,5 @@ cache:
     - 'node_modules'
 
 script:
-  - npm lint
-  - npm test
+  - npm run lint
+  - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - 'stable'
+  - '10'
+  
 install:
   - npm install
 cache:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.3",
+    "@zeit/next-sass": "^1.0.1",
     "auth0-js": "^9.10.2",
     "autoprefixer": "^9.5.1",
     "babel-plugin-module-resolver": "^3.2.0",
@@ -25,6 +26,7 @@
     "mongoose": "^5.5.2",
     "morgan": "^1.9.1",
     "next": "8.0.4",
+    "node-sass": "^4.11.0",
     "passport": "^0.4.0",
     "passport-auth0": "^1.1.0",
     "postcss-easy-import": "^3.0.0",
@@ -42,7 +44,6 @@
     "@babel/core": "^7.4.3",
     "@babel/plugin-transform-arrow-functions": "^7.2.0",
     "@babel/preset-env": "^7.4.3",
-    "@zeit/next-sass": "^1.0.1",
     "babel-eslint": "^10.0.1",
     "chai": "^4.2.0",
     "chai-http": "^4.2.1",
@@ -60,7 +61,6 @@
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^24.7.1",
     "mocha": "^6.1.2",
-    "node-sass": "^4.11.0",
     "prettier": "^1.17.0",
     "sinon": "^7.3.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "create-next-example-app",
   "scripts": {
-    "dev": "nodemon server/server.js",
+    "dev": "next",
+    "dev:server": "nodemon server/server.js",
     "build": "next build ",
     "start": "next start",
     "lint": "eslint server/ --fix",
@@ -9,7 +10,6 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.3",
-    "@zeit/next-sass": "^1.0.1",
     "auth0-js": "^9.10.2",
     "autoprefixer": "^9.5.1",
     "babel-plugin-module-resolver": "^3.2.0",
@@ -25,7 +25,6 @@
     "mongoose": "^5.5.2",
     "morgan": "^1.9.1",
     "next": "8.0.4",
-    "node-sass": "^4.11.0",
     "passport": "^0.4.0",
     "passport-auth0": "^1.1.0",
     "postcss-easy-import": "^3.0.0",
@@ -43,6 +42,7 @@
     "@babel/core": "^7.4.3",
     "@babel/plugin-transform-arrow-functions": "^7.2.0",
     "@babel/preset-env": "^7.4.3",
+    "@zeit/next-sass": "^1.0.1",
     "babel-eslint": "^10.0.1",
     "chai": "^4.2.0",
     "chai-http": "^4.2.1",
@@ -60,6 +60,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^24.7.1",
     "mocha": "^6.1.2",
+    "node-sass": "^4.11.0",
     "prettier": "^1.17.0",
     "sinon": "^7.3.1"
   }


### PR DESCRIPTION
Travis tests were failing because node-sass which is a dependency could not be installed. I later found out that this was because we set travis to use the latest version of node (v12). Bumping down the node version to 10, fixed this